### PR TITLE
Fixed pdu sms klass refered as class

### DIFF
--- a/doc/tutorial/sms.rst
+++ b/doc/tutorial/sms.rst
@@ -56,7 +56,7 @@ Setting the SMS class (0-3) is a no brainer::
     from messaging.sms import SmsSubmit
 
     sms = SmsSubmit("+44123231231", "hey how's it going?")
-    sms.class = 0
+    sms.klass = 0
     pdu = sms.to_pdu()[0]
 
     print(pdu.length, pdu.pdu)


### PR DESCRIPTION
The documentation suggests to set class for SMS as `sms.class`, class is a reserved keyword in python and using `sms.class` is syntatically not correct. When I looked at the code, I foud it was `klass` rather than `class`